### PR TITLE
Changed capture_mouse to be more generic

### DIFF
--- a/jellyfin_mpv_shim/menu.py
+++ b/jellyfin_mpv_shim/menu.py
@@ -125,7 +125,7 @@ class OSDMenu(object):
         self.playerManager.set_osd_settings("#CC333333", 40)
 
         self.playerManager.enable_osc(False)
-        self.playerManager.capture_mouse(True)
+        self.playerManager.triggered_menu(True)
 
         self.menu_title = _("Main Menu")
         self.menu_selection = 0
@@ -199,7 +199,7 @@ class OSDMenu(object):
             self.playerManager.show_text("", 0, 0)
 
             self.playerManager.enable_osc(True)
-            self.playerManager.capture_mouse(False)
+            self.playerManager.triggered_menu(False)
             self.playerManager.force_window(False)
 
             if not self.playerManager.playback_is_aborted():

--- a/jellyfin_mpv_shim/player.py
+++ b/jellyfin_mpv_shim/player.py
@@ -954,7 +954,7 @@ class PlayerManager(object):
         if hasattr(self._player, "osc"):
             self._player.osc = enabled
 
-    def capture_mouse(self, enabled: bool):
+    def triggered_menu(self, enabled: bool):
         self._player.command(
             "script-message", "shim-menu-enable", "True" if enabled else "False"
         )


### PR DESCRIPTION
Changed `capture_mouse` to `triggered_menu`
The current capture_mouse event is triggered when the menu shows. This is more generic as the event can be used for various lua scripts other than mouse capture. 