### PR TITLE
Fix bugs #191, #194, #193

### DIFF
--- a/Jellyfin MPV Desktop.iss
+++ b/Jellyfin MPV Desktop.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Jellyfin Desktop"
-#define MyAppVersion "1.10.1"
+#define MyAppVersion "1.10.2"
 #define MyAppPublisher "Ian Walton"
 #define MyAppURL "https://github.com/jellyfin/jellyfin-desktop"
 #define MyAppExeName "run-desktop.exe"

--- a/jellyfin_mpv_shim/clients.py
+++ b/jellyfin_mpv_shim/clients.py
@@ -115,6 +115,9 @@ class ClientManager(object):
     def login(
         self, server: str, username: str, password: str, force_unique: bool = False
     ):
+        if server.endswith("/"):
+            server = server[:-1]
+        
         protocol, host, port, path = path_regex.match(server).groups()
 
         if not protocol:

--- a/jellyfin_mpv_shim/constants.py
+++ b/jellyfin_mpv_shim/constants.py
@@ -1,6 +1,6 @@
 APP_NAME = "jellyfin-mpv-shim"
 USER_APP_NAME = "Jellyfin MPV Shim"
-CLIENT_VERSION = "1.10.1"
+CLIENT_VERSION = "1.10.2"
 USER_AGENT = "Jellyfin-MPV-Shim/%s" % CLIENT_VERSION
 CAPABILITIES = {
     "PlayableMediaTypes": "Video",

--- a/jellyfin_mpv_shim/integration/com.github.iwalton3.jellyfin-mpv-shim.appdata.xml
+++ b/jellyfin_mpv_shim/integration/com.github.iwalton3.jellyfin-mpv-shim.appdata.xml
@@ -60,6 +60,16 @@
 
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.10.2" date="2021-03-25">
+      <description>
+        <p>This release fixes some important bugs. Changes:</p>
+        <ul>
+            <li>#191 Playing media from episode page crashes player logic and doesn't set subtitle/audio streams.</li>
+            <li>#194 Fix erratic navigation in webclient caused by sending back bad display mirror events.</li>
+            <li>#193 Handle trailing slashes in server URLs.</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.10.1" date="2021-03-24">
       <description>
         <p>This release fixes websocket forwarding and casting in the desktop client. Changes:</p>

--- a/jellyfin_mpv_shim/webclient_view/__init__.py
+++ b/jellyfin_mpv_shim/webclient_view/__init__.py
@@ -127,12 +127,14 @@ class Server(threading.Thread):
             server_id = event["ServerId"]
             if type(event) is dict and "value" in event and len(event) == 2:
                 event = event["value"]
-            pl_event_queue.put({
-                "dest": "ws",
-                "MessageType": name,
-                "Data": event,
-                "ServerId": server_id
-            })
+            pl_event_queue.put(
+                {
+                    "dest": "ws",
+                    "MessageType": name,
+                    "Data": event,
+                    "ServerId": server_id,
+                }
+            )
 
         playerManager.on_playstate = on_playstate
         eventHandler.it_on_event = it_on_event
@@ -240,7 +242,9 @@ class Server(threading.Thread):
             if client is None:
                 log.warning("Message recieved but no client available. Ignoring.")
                 return resp
-            eventHandler.handle_event(client, req["name"], req["payload"])
+            eventHandler.handle_event(
+                client, req["name"], req["payload"], from_web=True
+            )
             return resp
 
         @app.route("/mpv_shim_wsmessage", methods=["POST"])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="jellyfin-mpv-shim",
-    version="1.10.1",
+    version="1.10.2",
     author="Ian Walton",
     author_email="iwalton3@gmail.com",
     description="Cast media from Jellyfin Mobile and Web apps to MPV.",


### PR DESCRIPTION
#191 Playing media from episode page crashes player logic and doesn't set subtitle/audio streams.
#194 Fix erratic navigation in webclient caused by sending back bad display mirror events.
#193 Handle trailing slashes in server URLs.