### PR TITLE
Inject nativeshell script at the profile level to fix first-load race

### DIFF
--- a/src/ui/webview.qml
+++ b/src/ui/webview.qml
@@ -275,7 +275,7 @@ Window
         worldId: WebEngineScript.MainWorld
       }
 
-      web.userScripts.collection = [ nativeshell ];
+      web.profile.userScripts.collection = [ nativeshell ];
     }
 
     onLoadingChanged: function(loadingInfo)


### PR DESCRIPTION
**Changes**
On startup the WebEngineView first shows the bundled qrc find-webclient page and then navigates to the server web client. That cross-origin navigation moves the view to a new renderer process, and a user script registered on the view is not reliably delivered to it, so the first load of the web client comes up without `window.NativeShell`. jellyfin-web then falls back to its HTML video player: playback works, but the native mpv player, MPRIS, and client settings are silently unavailable until the page is reloaded. Registering the script on the profile instead applies it to every load, including the first. Verified on Linux (Arch, Qt 6.11.2, Wayland): before the change `window.jmpInfo` was undefined on every cold start until a reload; after, it is present on the first load, and the mpv player plugins register immediately.

**Code assistance**
Debugged and patch prepared with LLM assistance (Claude); diagnosis verified against a running instance via QtWebEngine remote debugging, and the fix tested across multiple cold starts.

**Issues**
None filed; happy to open one if preferred.